### PR TITLE
Request should propagate 400 responses

### DIFF
--- a/client.go
+++ b/client.go
@@ -92,6 +92,14 @@ func (c *defaultMetaClient) Fetch(slug string) (dashboard Dashboard, err error) 
 	resp, err := NewRequest(url)
 
 	if err != nil {
+		switch err {
+		case ErrBadRequest:
+			if body, readErr := ReadResponseBody(resp); readErr == nil {
+				c.log.Errorf("Bad request to URL %q with result %q", url, body)
+			}
+		case ErrNotFound:
+			c.log.Errorf("Not found: %q", url)
+		}
 		return
 	}
 

--- a/data.go
+++ b/data.go
@@ -61,7 +61,16 @@ func (client *defaultDataClient) Fetch(dataGroup, dataType string, dataQuery Que
 	}).Debug("Requesting performance data for slug")
 
 	backdropResponse, err := NewRequest(url, client.options...)
+
 	if err != nil {
+		switch err {
+		case ErrBadRequest:
+			if body, readErr := ReadResponseBody(backdropResponse); readErr == nil {
+				client.log.Errorf("Bad request to URL %q with result %q", url, body)
+			}
+		case ErrNotFound:
+			client.log.Errorf("Not found: %q", url)
+		}
 		return nil, err
 	}
 

--- a/request.go
+++ b/request.go
@@ -29,6 +29,8 @@ func (ro *RequestOptions) option(req *http.Request, opts ...Option) (previous Op
 var (
 	// ErrNotFound is an error indicating that the server returned a 404.
 	ErrNotFound = errors.New("not found")
+	// ErrBadRequest is an error indicating that the client request had a problem.
+	ErrBadRequest = errors.New("bad request")
 )
 
 // NewRequest tries to make a request to the URL, returning the http.Response if it was successful, or an error if there was a problem.
@@ -55,6 +57,10 @@ func NewRequest(url string, options ...Option) (*http.Response, error) {
 
 	if response.StatusCode == http.StatusNotFound {
 		return nil, ErrNotFound
+	}
+
+	if response.StatusCode == http.StatusBadRequest {
+		return response, ErrBadRequest
 	}
 
 	return response, err

--- a/request_test.go
+++ b/request_test.go
@@ -114,6 +114,21 @@ var _ = Describe("NewRequest", func() {
 		Expect(err).ShouldNot(BeNil())
 		Expect(err).Should(Equal(ErrNotFound))
 	})
+
+	It("propagates 400s", func() {
+		ts := testServer(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, `{
+message: "Either 'duration' or both 'start_at' and 'end_at' are required for a period query",
+status: "error"
+}`)
+		})
+		defer ts.Close()
+		response, err := NewRequest(ts.URL, BearerToken("FOO"))
+		Expect(response).ShouldNot(BeNil())
+		Expect(err).ShouldNot(BeNil())
+		Expect(err).Should(Equal(ErrBadRequest))
+	})
 })
 
 func testServer(handler interface{}) *httptest.Server {


### PR DESCRIPTION
As a client, I’d like to know when developing my app whether I’m using the
server API correctly or not.